### PR TITLE
feat: add size badges to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@
   <a href="https://github.com/hellhub-collective/sdk/actions/workflows/test.yml">
     <img src="https://github.com/hellhub-collective/sdk/actions/workflows/test.yml/badge.svg" alt="Tests" />
   </a>
+  <a href="https://bundlephobia.com/package/@hellhub-collective/sdk">
+    <img src="https://img.shields.io/bundlephobia/min/@hellhub-collective/sdk" alt="Bundle Size (Minified)" />
+  </a>
+  <a href="https://bundlephobia.com/package/@hellhub-collective/sdk">
+    <img src="https://img.shields.io/bundlephobia/minzip/@hellhub-collective/sdk" alt="alt="Bundle Size (Minified & Zipped)" />
+  </a>
 </p>
 
 ## What is the HellHub SDK?


### PR DESCRIPTION
## Description

This PR adds badges to the readme file that contain the `minified` and `minifed & zipped` sizes for the package, both badges link to [bundlephobia](https://bundlephobia.com/package/@hellhub-collective/sdk).

### Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
