### PR TITLE
fix: correctly name `statistic` property

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "license": "MIT",
   "private": false,
   "description": "The official SDK for HellHub API. Filter and collect data with full type safety out of the box.",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "main": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "keywords": [

--- a/types/api-entities.ts
+++ b/types/api-entities.ts
@@ -51,7 +51,7 @@ export interface Planet extends RemoteEntity {
   disabled: boolean;
   positionX: number;
   positionY: number;
-  statistics?: Stat;
+  statistic?: Stat;
   statisticId: number;
   attacking: Attack[];
   defending: Attack[];


### PR DESCRIPTION
## Description

This PR fixes a type error on the planet modal by renaming the currently wrong `statistics` property to `statistic`.

### Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
