### PR TITLE
feat: add liberation fields to type definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "license": "MIT",
   "private": false,
   "description": "The official SDK for HellHub API. Filter and collect data with full type safety out of the box.",
-  "version": "1.0.5",
+  "version": "1.1.0",
   "main": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "keywords": [

--- a/types/api-entities.ts
+++ b/types/api-entities.ts
@@ -48,6 +48,9 @@ export interface Planet extends RemoteEntity {
   orders?: Order[];
   maxHealth: number;
   players: number;
+  liberation: number;
+  liberationRate: number;
+  liberationState: "WINNING" | "DRAW" | "LOSING" | "N/A";
   disabled: boolean;
   positionX: number;
   positionY: number;


### PR DESCRIPTION
## Description

Added the liberation progress fields to the type definition for the `Planet` model. Upstream PR needs to be merged before this can be merged.

Related to [#38](https://github.com/hellhub-collective/api/pull/38)

### Type of change

<!-- Please delete options that are not relevant. -->

- [x] Refractor (non-breaking change which cleans up code)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
