### PR TITLE
fix: correctly set types for dynamic request functions

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -8,7 +8,9 @@ import {
 import type {
   War,
   Stat,
+  Biome,
   Order,
+  Effect,
   Attack,
   Planet,
   Sector,
@@ -156,7 +158,7 @@ class SDK {
    *
    * Endpoint: `/api/biomes(/:id)`
    */
-  biomes = generateDynamicRequestFn<Assignment>("biomes");
+  biomes = generateDynamicRequestFn<Biome>("biomes");
 
   /**
    * ### Environmental Effects
@@ -166,7 +168,7 @@ class SDK {
    *
    * Endpoint: `/api/effects(/:id)`
    */
-  effects = generateDynamicRequestFn<Assignment>("effects");
+  effects = generateDynamicRequestFn<Effect>("effects");
 }
 
 const HellHub = SDK.getInstance();

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "license": "MIT",
   "private": false,
   "description": "The official SDK for HellHub API. Filter and collect data with full type safety out of the box.",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "main": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "keywords": [


### PR DESCRIPTION
## Description

This PR resolves an issue with the type inference for the new `Biome` and `Effect` handlers.

### Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
