### PR TITLE
feat: add cron job endpoints

### DIFF
--- a/__tests__/utils/request-generator.test.ts
+++ b/__tests__/utils/request-generator.test.ts
@@ -2,11 +2,36 @@ import "__mocks__/utils/request";
 
 import {
   generateDynamicRequestFn,
+  generatePrimitiveRequestFn,
   generateSingleRequestFn,
 } from "utils/request-generator";
 
 import { it, expect } from "bun:test";
-import type { Planet } from "types/api-entities";
+import type { Cron, Planet } from "types/api-entities";
+
+it("PrimitiveRequestFn works as expected", async () => {
+  // @ts-expect-error
+  const primitiveRequest = generatePrimitiveRequestFn<Cron>("/api/crons");
+
+  const response1 = await primitiveRequest("refresh_from_source");
+  const response2 = await primitiveRequest();
+
+  expect(response1.ok).toBe(true);
+  expect(response2.ok).toBe(true);
+
+  expect(response1.url).toBe("/api/crons/refresh_from_source");
+  expect(response2.url).toBe("/api/crons");
+
+  const json1 = await response1.json();
+  const json2 = await response2.json();
+
+  expect(json1).toHaveProperty("data", null);
+  expect(json1).toHaveProperty("error", null);
+
+  expect(json2).toHaveProperty("data", null);
+  expect(json2).toHaveProperty("error", null);
+  expect(json2).toHaveProperty("pagination", null);
+});
 
 it("SingleRequestFn works as expected", async () => {
   const singleRequest = generateSingleRequestFn<Planet>("https://example.com");

--- a/index.ts
+++ b/index.ts
@@ -1,13 +1,15 @@
 import { request } from "utils/request";
 
 import {
-  generateDynamicRequestFn,
   generateSingleRequestFn,
+  generateDynamicRequestFn,
+  generatePrimitiveRequestFn,
 } from "utils/request-generator";
 
 import type {
   War,
   Stat,
+  Cron,
   Biome,
   Order,
   Effect,
@@ -169,6 +171,15 @@ class SDK {
    * Endpoint: `/api/effects(/:id)`
    */
   effects = generateDynamicRequestFn<Effect>("effects");
+
+  /**
+   * ### Crons
+   *
+   * Allows you to track the internal cron jobs. Fine tune your periodic requests to the
+   * API and avoid hitting request limits by over fetching.
+   */
+  // @ts-ignore
+  crons = generatePrimitiveRequestFn<Cron>("crons");
 }
 
 const HellHub = SDK.getInstance();

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "license": "MIT",
   "private": false,
   "description": "The official SDK for HellHub API. Filter and collect data with full type safety out of the box.",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "main": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "keywords": [

--- a/types/api-entities.ts
+++ b/types/api-entities.ts
@@ -4,6 +4,18 @@ import type { QueryOptions } from "types/query-generator";
  * Base types
  */
 
+export interface Cron {
+  name: string;
+  pattern: string;
+  status: "ok" | "stopped";
+  busy: boolean;
+  runs: {
+    next: number | null;
+    current: number | null;
+    previous: number | null;
+  };
+}
+
 export interface Entity {
   id: number;
   createdAt: string;

--- a/utils/request-generator.ts
+++ b/utils/request-generator.ts
@@ -8,7 +8,7 @@ import type {
 } from "types/api-entities";
 
 /**
- * Creates a request function for a given entity, which can be used to fetch
+ * Creates a request function for a given endpoint, which can be used to fetch
  * from a endpoint that does not support any query parameters.
  */
 export function generatePrimitiveRequestFn<T extends Entity>(entity: string) {

--- a/utils/request-generator.ts
+++ b/utils/request-generator.ts
@@ -9,6 +9,37 @@ import type {
 
 /**
  * Creates a request function for a given entity, which can be used to fetch
+ * from a endpoint that does not support any query parameters.
+ */
+export function generatePrimitiveRequestFn<T extends Entity>(entity: string) {
+  async function requestFn(
+    input?: Omit<APIRequestInit<T[]>, "query">,
+    options?: undefined,
+  ): Promise<APIResponse<T[]>>;
+
+  async function requestFn(
+    input: number | string,
+    options?: Omit<APIRequestInit<T[]>, "query">,
+  ): Promise<APIResponse<T>>;
+
+  async function requestFn(
+    input: Omit<APIRequestInit<T[]>, "query"> | undefined | number | string,
+    options?: APIRequestInit<T[]> | APIRequestInit<T>,
+  ): Promise<APIResponse<T[]> | APIResponse<T>> {
+    if (typeof input === "object" || input === undefined) {
+      return request(entity, { ...input }) as Promise<APIResponse<T[]>>;
+    } else {
+      return request(`${entity}/${input}`, {
+        ...(options as APIRequestInit<T>),
+      }) as Promise<APIResponse<T>>;
+    }
+  }
+
+  return requestFn;
+}
+
+/**
+ * Creates a request function for a given entity, which can be used to fetch
  * data from the API.
  */
 export function generateDynamicRequestFn<T extends Entity>(entity: string) {


### PR DESCRIPTION
## Description

Following the release [v2.7.0](https://github.com/hellhub-collective/api/releases/tag/v2.7.0) of the API we added new endpoints to the SDK. This introduces endpoints that alllow you to track the internal cron jobs, like the one that fetches the source data from Arrowhead's API:

```typescript
const response = await Hellhub.crons("refresh_from_source");
```

This allows you to better fine tune your periodic requests to the API and prevent hitting request limits by eliminating the need for aimless overfetching.

### Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Added a new test for the `generatePrimitiveRequestFn` function that has been created to support requests to endpoints that do not support the default query parameters.

- `__tests__/utils/request-generator.ts`

### Test Configuration

- Bun version: 1.1.3
- API Hosting (Selfhosted, By Hellhub Collective, etc): By Hellhub Collective

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
