### PR TITLE
chore(types): add image url to planet type

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "license": "MIT",
   "private": false,
   "description": "The official SDK for HellHub API. Filter and collect data with full type safety out of the box.",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "main": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "keywords": [

--- a/types/api-entities.ts
+++ b/types/api-entities.ts
@@ -56,6 +56,7 @@ export interface Planet extends RemoteEntity {
   ownerId: number;
   sector: Sector;
   sectorId: number;
+  imageUrl: string;
   effects: Effect[];
   biome: Biome;
   biomeId: number;


### PR DESCRIPTION
## Description

This PR adds the `imageUrl` property to the `Planet` type. This field contains a link to a webp containg the planets texture when viewed on the galactic map as celestial body.

### Type of change

<!-- Please delete options that are not relevant. -->

- [x] Refractor (non-breaking change which cleans up code)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
