### PR TITLE
feat: add assignment task types

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "license": "MIT",
   "private": false,
   "description": "The official SDK for HellHub API. Filter and collect data with full type safety out of the box.",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "main": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "keywords": [

--- a/types/api-entities.ts
+++ b/types/api-entities.ts
@@ -174,15 +174,24 @@ export interface Reward extends RemoteEntity {
   assignment?: Assignment;
 }
 
+export interface AssignmentTask extends Entity {
+  type: number;
+  values: number[];
+  valueTypes: number[];
+  assignmentId: number;
+  assignment?: Assignment;
+}
+
 export interface Assignment extends RemoteEntity {
   type: number;
   title: string;
   briefing: string;
   reward?: Reward;
   rewardId: number;
-  progress: number;
+  progress: number[];
   expiresAt: string;
   description: string;
+  tasks: AssignmentTask[];
 }
 
 export interface Biome extends Entity {


### PR DESCRIPTION
## Description

This release updates the type definitions to include the `AssignmentTask` type that was recently added to the `Assignment` model and describes the fulfillment requirements for a major order.

```typescript
export interface AssignmentTask extends Entity {
  type: number;
  values: number[];
  valueTypes: number[];
  assignmentId: number;
  assignment?: Assignment;
}
```

### Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
